### PR TITLE
fix: use aborted event for activity requests

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -2432,8 +2432,12 @@ app.post('/api/activities', async (req, res) => {
   console.log(`🚀 [SERVER DEBUG ${requestId}] New /api/activities request started`);
   console.log(`🚀 [SERVER DEBUG ${requestId}] Request headers:`, req.headers);
   
-  req.on('close', () => {
-    console.log(`🚫 [SERVER DEBUG ${requestId}] Request 'close' event triggered`);
+  // Use the 'aborted' event which only fires when the client truly
+  // terminates the request before a response is sent. The previous
+  // implementation listened for 'close', which can fire in normal
+  // circumstances and led to legitimate searches being cancelled.
+  req.on('aborted', () => {
+    console.log(`🚫 [SERVER DEBUG ${requestId}] Request 'aborted' event triggered`);
     console.log(`🚫 [SERVER DEBUG ${requestId}] Response headers sent:`, res.headersSent);
     if (!res.headersSent) {
       console.log(`⚠️ [SERVER DEBUG ${requestId}] Client disconnected, cancelling search request`);


### PR DESCRIPTION
## Summary
- use `aborted` request event instead of `close` to detect client cancellations in activity search endpoint

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c166adbb6c83329c4e93b89a6110d8