### PR TITLE
Fix settings modal truncation on small screens

### DIFF
--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -317,8 +317,8 @@ export default function Settings({ isOpen, onClose }: SettingsProps) {
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4 mobile-settings-overlay">
-      <div className="bg-white rounded-2xl shadow-2xl max-w-4xl w-full max-h-[90vh] sm:max-h-[90vh] max-h-[calc(100vh-2rem)] flex flex-col mobile-settings-modal">
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-start sm:items-center z-50 p-4 overflow-y-auto mobile-settings-overlay">
+      <div className="bg-white rounded-2xl shadow-2xl max-w-4xl w-full max-h-[calc(100dvh-2rem)] flex flex-col mobile-settings-modal">
         <div className="p-6 border-b border-gray-200 flex-shrink-0">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-3">


### PR DESCRIPTION
## Summary
- allow modal overlay to scroll and use dynamic viewport height to avoid clipping

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68c2f6ada91c83328783437ff488073f