### PR TITLE
Rename duration field label to activity duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ kef/
 ### Search Interface
 - **Location Input**: Smart city search with autocomplete
 - **Date Selection**: Calendar picker with date validation
-- **Duration**: Flexible time input (hours)
+- **Activity Duration**: Flexible time input (hours)
 - **Ages**: Multi-select age range picker
 - **Categories**: Filter by activity types
 - **Extra Instructions**: Custom requirements

--- a/src/v2/pages/SearchPage.tsx
+++ b/src/v2/pages/SearchPage.tsx
@@ -393,7 +393,7 @@ export default function SearchPage({
               </div>
               <div className="glass-input flex flex-col">
                 <div className="flex items-center justify-between mb-1">
-                  <span className="text-sm font-medium text-gray-700">Duration</span>
+                  <span className="text-sm font-medium text-gray-700">Activity Duration</span>
                   <span className="text-sm font-bold text-gray-800">
                     {searchParams.duration === 10 ? '10+' : searchParams.duration} hours
                   </span>


### PR DESCRIPTION
## Summary
- rename search form's "Duration" label to "Activity Duration"
- document search field as Activity Duration in README

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68c2f81ec09c833284e80b902c3aa6f3