### PR TITLE
Fix address underline and add map links

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
+    <meta name="format-detection" content="telephone=no,address=no,email=no,url=no" />
     <title>FunFindAI</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/src/v2/pages/ResultsPage.tsx
+++ b/src/v2/pages/ResultsPage.tsx
@@ -174,7 +174,17 @@ export default function ResultsPage({
           <div className="flex-1">
             <h1 className="text-lg font-semibold text-gray-900">Activity Results</h1>
             {ctx && (
-              <p className="text-sm text-gray-600">{ctx.location} • {new Date(ctx.date).toLocaleDateString()}</p>
+              <p className="text-sm text-gray-600">
+                <a
+                  href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(ctx.location)}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="hover:underline"
+                >
+                  {ctx.location}
+                </a>{' '}
+                • {new Date(ctx.date).toLocaleDateString()}
+              </p>
             )}
           </div>
         </div>
@@ -271,7 +281,16 @@ export default function ResultsPage({
                     {showPrompt ? '🔍 Hide Prompt' : '🔍 View AI Prompt'}
                   </button>
                 )}
-                <div className="text-sm text-gray-500">{ctx.location}</div>
+                <div className="text-sm text-gray-500">
+                  <a
+                    href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(ctx.location)}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="hover:underline"
+                  >
+                    {ctx.location}
+                  </a>
+                </div>
               </div>
             </div>
             
@@ -534,9 +553,14 @@ export default function ResultsPage({
                           </div>
                         </div>
                         {a.address && (
-                          <div className="text-[13px] text-gray-600 mt-1 flex items-center gap-1">
+                          <a
+                            href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(a.address)}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-[13px] text-gray-600 mt-1 flex items-center gap-1 hover:underline"
+                          >
                             <span>📍</span>{a.address}
-                          </div>
+                          </a>
                         )}
                       </div>
                     </div>


### PR DESCRIPTION
## Summary
- prevent iOS from auto-linking addresses
- make search and activity locations open Google Maps when clicked

## Testing
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c333fa28ac8332a49b2d27463a05a3