### PR TITLE
Align splash screen imagery with loading screen

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -1619,27 +1619,39 @@ body { font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, "Helvetic
   pointer-events: none;
 }
 
-.splash-top,
-.splash-bottom {
+.splash-layer {
   position: absolute;
-  width: 100%;
-  height: 50%;
+  inset: 0;
   overflow: hidden;
+  pointer-events: none;
 }
 
 .splash-top {
-  top: 0;
+  clip-path: inset(0 0 50% 0);
   animation: slideUp 1.2s ease-in-out 1.8s forwards;
+  z-index: 2;
+  will-change: transform;
 }
 
 .splash-bottom {
-  bottom: 0;
+  clip-path: inset(50% 0 0 0);
   animation: slideDown 1.2s ease-in-out 1.8s forwards;
+  z-index: 1;
+  will-change: transform;
+}
+
+.splash-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 3;
+  pointer-events: none;
 }
 
 .splash-image {
+  position: absolute;
+  inset: 0;
   width: 100%;
-  height: 200%;
+  height: 100%;
   object-fit: cover;
   object-position: center;
 }
@@ -1663,15 +1675,6 @@ body { font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, "Helvetic
   }
 }
 
-.splash-top .splash-image {
-  object-position: center top;
-  transform: translateY(0);
-}
-
-.splash-bottom .splash-image {
-  object-position: center bottom;
-  transform: translateY(-50%);
-}
 
 @keyframes slideUp {
   0% {

--- a/src/v2/App.tsx
+++ b/src/v2/App.tsx
@@ -803,11 +803,12 @@ export default function App() {
       {/* Splash Screen Overlay */}
       {state.showSplash && (
         <div className="splash-screen">
-          <div className="splash-top">
+          <div className="splash-overlay glass-bg-overlay" />
+          <div className="splash-top splash-layer">
             <img src={getImageUrl('BGPC')} alt="Fun Finder" className="splash-image splash-image-desktop" />
             <img src={getImageUrl('BG7')} alt="Fun Finder" className="splash-image splash-image-mobile" />
           </div>
-          <div className="splash-bottom">
+          <div className="splash-bottom splash-layer">
             <img src={getImageUrl('BGPC')} alt="Fun Finder" className="splash-image splash-image-desktop" />
             <img src={getImageUrl('BG7')} alt="Fun Finder" className="splash-image splash-image-mobile" />
           </div>


### PR DESCRIPTION
## Summary
- clip the splash screen image into matching top and bottom layers so the background lines up with the loading layout
- add the shared overlay gradient so the splash and loading screen imagery have the same visual treatment during the transition

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8542c684c83329b934f9306c07463